### PR TITLE
Fixed rotation issue

### DIFF
--- a/noeuclid.cpp
+++ b/noeuclid.cpp
@@ -679,7 +679,7 @@ void DoneProbes( bool bReRun )
 
 	float newquat[4];
 	quatfrommatrix( newquat, orotmat );
-	quatnormalize( LookQuaternion, newquat );
+	//quatnormalize( LookQuaternion, newquat );
 
 
 	//Attempt to re-right the player


### PR DESCRIPTION
On my system, mouse rotation wasn't working due to the
quaternion being normalized. I do not claim to understand
this, but now the rendering / rotation works. There are still
other issues (on my system), such as time being very fast,
that I may try to "fix" in the future.

This may not be correct, and may even break things on
other systems, but it fixes the problem on my system.
