### PR TITLE
Fixed compiling errors on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,12 @@ OBJS=$(subst .cpp,.o,$(SRCS))
 
 
 #otherwise... uncomment this
-LDFLAGS:=$(LDFLAGS) -lsfml-graphics -lsfml-window -lsfml-system
+LDFLAGS:=$(LDFLAGS) -I/usr/local/include/ -L /usr/local/lib/ -lsfml-graphics -lsfml-window -lsfml-system
 
-CXXFLAGS:=$(CXXFLAGS) -std=c++11 -DGLEW_STATIC -DGL_GLEXT_PROTOTYPES -g -Wall -O2
+CXXFLAGS:=$(CXXFLAGS) -std=c++11 -DGLEW_STATIC -DGL_GLEXT_PROTOTYPES -I/usr/local/include/ -g -Wall -O2
 LDFLAGS:=$(LDFLAGS) -g -Wall
 
-LDLIBS:=$(LDFLAGS) $(LDLIBS) -lGLEW -lGLU -lGL -ltcc -ldl
+LDLIBS:=$(LDFLAGS) $(LDLIBS) -framework GLUT -framework OpenGL -framework Cocoa -lGLEW -ltcc -ldl
 LINK.o = $(LINK.cc)
 
 WINCXXFLAGS:=-DGLEXT -std=c++11 -g -O2 -IWindows -IWindows/SFML-2.2/include -DGLEW_STATIC  -DDrawText=DrawText

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,20 @@ all: noeuclid
 SRCS=$(wildcard *.cpp)
 OBJS=$(subst .cpp,.o,$(SRCS))
 
+OS:=$(shell uname)
 
-#otherwise... uncomment this
-LDFLAGS:=$(LDFLAGS) -I/usr/local/include/ -L /usr/local/lib/ -lsfml-graphics -lsfml-window -lsfml-system
-
-CXXFLAGS:=$(CXXFLAGS) -std=c++11 -DGLEW_STATIC -DGL_GLEXT_PROTOTYPES -I/usr/local/include/ -g -Wall -O2
+LDFLAGS:=$(LDFLAGS) -lsfml-graphics -lsfml-window -lsfml-system
+CXXFLAGS:=$(CXXFLAGS) -std=c++11 -DGLEW_STATIC -DGL_GLEXT_PROTOTYPES -g -Wall -O2
 LDFLAGS:=$(LDFLAGS) -g -Wall
-
-LDLIBS:=$(LDFLAGS) $(LDLIBS) -framework GLUT -framework OpenGL -framework Cocoa -lGLEW -ltcc -ldl
 LINK.o = $(LINK.cc)
+
+ifeq ($(OS),Darwin)
+  LDFLAGS:=$(LDFLAGS) -I/usr/local/include/ -L /usr/local/lib/
+  CXXFLAGS:=$(CXXFLAGS) -I/usr/local/include/
+  LDLIBS:=$(LDFLAGS) $(LDLIBS) -framework GLUT -framework OpenGL -framework Cocoa -lGLEW -ltcc -ldl
+else
+  LDLIBS:=$(LDFLAGS) $(LDLIBS) -lGLEW -lGLU -lGL -ltcc -ldl
+endif
 
 WINCXXFLAGS:=-DGLEXT -std=c++11 -g -O2 -IWindows -IWindows/SFML-2.2/include -DGLEW_STATIC  -DDrawText=DrawText
 WINLDFL:=Windows/libtcc.a -LWindows/SFML-2.2/lib -lglew -lsfml-graphics -lsfml-window -lsfml-system -lopengl32 -lkernel32 -lm -lgdiplus -lole32 -lglu32 -lopengl32  ./libtcc1.a


### PR DESCRIPTION
I tried to compile on OSX 10.10 with all required libraries and tcc installed (all with homebrew) and linked in /usr/local/include and there were linking errors and header files not found.

I changed the flags (```-lGLEW -lGLU -lGL```) to frameworks (-```framework GLUT -framework OpenGL -framework Cocoa```) to fix GLU and the directories for tcc and sfml (```-I/usr/local/include/ -L /usr/local/lib/```).

Also, I have not tried to compile on any GNU/Linux distro, but I think it should work as I only changed what's inside the conditional.